### PR TITLE
Cheaty Recipe to craft rotten flesh into leather.

### DIFF
--- a/Test_Pack_1.13/data/testpack/advancements/leather.json
+++ b/Test_Pack_1.13/data/testpack/advancements/leather.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "testpack:leather"
+    ]
+  },
+  "criteria": {
+    "has_rotten_flesh": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:rotten_flesh"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_rotten_flesh"
+    ]
+  ]
+}

--- a/Test_Pack_1.13/data/testpack/recipes/leather.json
+++ b/Test_Pack_1.13/data/testpack/recipes/leather.json
@@ -1,0 +1,16 @@
+{
+  "type": "crafting_shaped",
+  "pattern": [
+    "##",
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stone"
+    }
+  },
+  "result": {
+    "item": "minecraft:stone_bricks",
+    "count": 4
+  }
+}


### PR DESCRIPTION
Cheaty Recipe to craft rotten flesh into leather. 4x Rotten Flesh = 1 Leather  w/Advancement