### PR TITLE
Utility Time Scoreboard objectives.

### DIFF
--- a/Test_Pack_1.13/data/minecraft/models/item/.gitignore
+++ b/Test_Pack_1.13/data/minecraft/models/item/.gitignore
@@ -1,0 +1,1 @@
+/iron_nugget.json

--- a/Test_Pack_1.13/data/minecraft/tags/functions/load.json
+++ b/Test_Pack_1.13/data/minecraft/tags/functions/load.json
@@ -1,6 +1,7 @@
 {
 	"replace":false,
 	"values":[
-		"testpack:smp_sleep_load"
+		"testpack:smp_sleep_load",
+		"testpack:time_load"
 	]
 }

--- a/Test_Pack_1.13/data/minecraft/tags/functions/tick.json
+++ b/Test_Pack_1.13/data/minecraft/tags/functions/tick.json
@@ -2,7 +2,7 @@
 	"replace":false,
 	"values":[
 		"testpack:netherwater",
-		"testpack:modify_ender_dragon_loot",
-		"testpack:smp_sleep_tick"
+		"testpack:smp_sleep_tick",
+		"testpack:time_tick"
 	]
 }

--- a/Test_Pack_1.13/data/minecraft/textures/items/.gitignore
+++ b/Test_Pack_1.13/data/minecraft/textures/items/.gitignore
@@ -1,0 +1,1 @@
+/diamond_nugget.png

--- a/Test_Pack_1.13/data/testpack/functions/time_load.mcfunction
+++ b/Test_Pack_1.13/data/testpack/functions/time_load.mcfunction
@@ -1,0 +1,3 @@
+scoreboard objectives add Time dummy Time
+scoreboard players add curTime Time 0
+scoreboard players add Day Time 0

--- a/Test_Pack_1.13/data/testpack/functions/time_tick.mcfunction
+++ b/Test_Pack_1.13/data/testpack/functions/time_tick.mcfunction
@@ -1,0 +1,2 @@
+execute store result score Day Time run time query day
+execute store result score curTime Time run time query daytime

--- a/Test_Pack_1.13/data/testpack/recipes/.gitignore
+++ b/Test_Pack_1.13/data/testpack/recipes/.gitignore
@@ -1,0 +1,1 @@
+/diamond_from_nuggets.json

--- a/Test_Pack_1.13/data/testpack/textures/items/.gitignore
+++ b/Test_Pack_1.13/data/testpack/textures/items/.gitignore
@@ -1,0 +1,1 @@
+/diamond_nugget.png


### PR DESCRIPTION
Add utility scoreboard functions to keep track of the current gametime in ticks 0-24,000 for 1 day, and Current day of the world. every time gametime hits 0 Day increments by 1. (/time set 0 will reset Day to 0)